### PR TITLE
Add interactive fruit store script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # codex-playground
+
+This repository contains small Python examples. Use the `fruit_store.py` script to interactively select fruit and calculate the total bill based on predefined prices.
+
+## Usage
+
+```bash
+python fruit_store.py
+```
+Follow the prompts to choose fruits and quantities, then type `done` to see your total bill.

--- a/fruit_store.py
+++ b/fruit_store.py
@@ -1,0 +1,34 @@
+FRUIT_PRICES = {
+    "apple": 1.00,
+    "banana": 0.50,
+    "orange": 0.80,
+    "grape": 2.50,
+    "mango": 1.50,
+}
+
+def main():
+    print("Available fruits and prices:")
+    for fruit, price in FRUIT_PRICES.items():
+        print(f"{fruit}: ${price:.2f}")
+
+    total = 0.0
+    while True:
+        choice = input("What fruit would you like to buy? (type 'done' to finish) ").strip().lower()
+        if choice == 'done':
+            break
+        if choice not in FRUIT_PRICES:
+            print("Sorry, that fruit is not available.")
+            continue
+        qty_input = input(f"How many {choice}s would you like? ").strip()
+        try:
+            qty = int(qty_input)
+        except ValueError:
+            print("Please enter a valid number for quantity.")
+            continue
+        total += FRUIT_PRICES[choice] * qty
+        print(f"Added {qty} {choice}(s) to your bill.")
+
+    print(f"Your total bill is ${total:.2f}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `fruit_store.py` for interactively selecting fruits and computing a bill
- document fruit store usage in README
- ignore Python cache files

## Testing
- `python -m py_compile fruit_store.py`
- `printf 'apple\n2\nbanana\n3\ndone\n' | python fruit_store.py`


------
https://chatgpt.com/codex/tasks/task_e_689783426d348331b2ba1cc75e6b6668